### PR TITLE
Direct Message usage support

### DIFF
--- a/src/bot/imagesmith.py
+++ b/src/bot/imagesmith.py
@@ -205,7 +205,7 @@ class ComfyUIBot(commands.Bot):
         """Handle image generation for all command types"""
         try:
             workflow_name = workflow or self.workflow_manager.get_default_workflow(workflow_type,
-                                                                                   channel_name=interaction.channel.name,
+                                                                                   channel_name=getattr(interaction.channel, 'name', None),
                                                                                    user_name=interaction.user.name)
             workflow_config = self.workflow_manager.get_workflow(workflow_name)
 

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -28,14 +28,15 @@ class SecurityManager:
             return SecurityResult(False, f"You don't have permission to use this workflow.")
 
         allowed_roles = security_config.get('allowed_roles', [])
-        member_roles = [role.name for role in member.roles]
+        if hasattr(member, 'roles'):
+            member_roles = [role.name for role in member.roles]
+            if len(allowed_roles) > 0 and not any(role in allowed_roles for role in member_roles):
+                return SecurityResult(False, f"You don't have required roles to use this workflow.")
 
-        if len(allowed_roles) > 0 and not any(role in allowed_roles for role in member_roles):
-            return SecurityResult(False, f"You don't have required roles to use this workflow.")
-
-        allowed_channels = security_config.get('allowed_channels', [])
-        if len(allowed_channels) > 0 and interaction.channel.name not in allowed_channels:
-            return SecurityResult(False, f"This workflow is not allowed on this channel.")
+        if hasattr(interaction, 'channel'):
+            allowed_channels = security_config.get('allowed_channels', [])
+            if len(allowed_channels) > 0 and interaction.channel.name not in allowed_channels:
+                return SecurityResult(False, f"This workflow is not allowed on this channel.")
 
         return SecurityResult(True)
 


### PR DESCRIPTION
Allows the bot to be used directly in DMs. These attributes only exist in channels, so we only fetch them when applicable. Without this PR the bot throws an unhelpful error to the user that the attribute does not exist.